### PR TITLE
Fix dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,9 +1,11 @@
 FROM ubuntu:18.04
+ENV DEBIAN_FRONTEND=noninteractive
 RUN apt update && apt upgrade -y
 RUN apt install build-essential -y
 RUN apt install git -y
 RUN apt install python3 python3-pip -y
 RUN apt install iverilog verilator gtkwave -y
+RUN pip3 install -U pip
 RUN pip3 install jinja2 pyverilog veriloggen numpy onnx
 RUN pip3 install torch torchvision
 RUN pip3 install pytest pytest-pythonpath


### PR DESCRIPTION
# Issue
I found 2 issues on `docker build`.

## build hangs-up due to interactive installation of tzdata
```
$ sudo docker build -t user/nngen .
...
Setting up tzdata (2019c-0ubuntu0.18.04) ...
debconf: unable to initialize frontend: Dialog
debconf: (TERM is not set, so the dialog frontend is not usable.)
debconf: falling back to frontend: Readline
Configuring tzdata
------------------

Please select the geographic area in which you live. Subsequent configuration
questions will narrow this down by presenting a list of cities, representing
the time zones in which they are located.

  1. Africa      4. Australia  7. Atlantic  10. Pacific  13. Etc
  2. America     5. Arctic     8. Europe    11. SystemV
  3. Antarctica  6. Asia       9. Indian    12. US
Geographic area: 

!! hangs-up here !!
```

## Pytorch installation fails
```
$ sudo docker build -t user/nngen .
...
Step 9/14 : RUN pip3 install torch torchvision
 ---> Running in 1fabfabfa648
Collecting torch
  Downloading https://files.pythonhosted.org/packages/88/95/90e8c4c31cfc67248bf944ba42029295b77159982f532c5689bcfe4e9108/torch-1.3.1-cp36-cp36m-manylinux1_x86_64.whl (734.6MB)
Killed
The command '/bin/sh -c pip3 install torch torchvision' returned a non-zero code: 137
```

# Solution
Add two commands in `Dockerfile`.
```
ENV DEBIAN_FRONTEND=noninteractive
RUN pip3 install -U pip
```
First one is for tzdata, and the other is for pytorch.
