### PR TITLE
feature add interrupt circit

### DIFF
--- a/nngen/__init__.py
+++ b/nngen/__init__.py
@@ -37,6 +37,7 @@ from .verilog import control_reg_extern_send, control_reg_extern_recv
 from .verilog import control_reg_global_offset
 from .verilog import control_reg_global_addr
 from .verilog import control_reg_load_global_addr_map, control_reg_busy_global_addr_map, control_reg_addr_global_addr_map
+from .verilog import control_reg_interrupt_isr, control_reg_interrupt_isr_busy, control_reg_interrupt_isr_extern, control_reg_interrupt_ier, control_reg_interrupt_iar
 
 from . import verify
 from . import sim

--- a/tests/matrix_extern_irq/Makefile
+++ b/tests/matrix_extern_irq/Makefile
@@ -1,0 +1,30 @@
+TARGET=$(shell ls *.py | grep -v test | grep -v parsetab.py)
+ARGS=
+
+PYTHON=python3
+#PYTHON=python
+#OPT=-m pdb
+#OPT=-m cProfile -s time
+#OPT=-m cProfile -o profile.rslt
+SIMTYPE=iverilog
+
+.PHONY: all
+all: test
+
+.PHONY: run
+run:
+	$(PYTHON) $(OPT) $(TARGET) $(ARGS)
+
+.PHONY: test
+test:
+	$(PYTHON) -m pytest -vv --sim $(SIMTYPE)
+
+.PHONY: check
+check:
+	$(PYTHON) $(OPT) $(TARGET) $(ARGS) > tmp.v
+	iverilog -tnull -Wall tmp.v
+	rm -f tmp.v
+
+.PHONY: clean
+clean:
+	rm -rf *.pyc __pycache__ parsetab.py .cache *.out *.png *.dot tmp.v uut.vcd

--- a/tests/matrix_extern_irq/matrix_extern_irq.py
+++ b/tests/matrix_extern_irq/matrix_extern_irq.py
@@ -1,0 +1,268 @@
+from __future__ import absolute_import
+from __future__ import print_function
+
+import os
+import sys
+import functools
+import math
+import numpy as np
+
+if sys.version_info.major < 3:
+    from itertools import izip_longest as zip_longest
+else:
+    from itertools import zip_longest
+
+# the next line can be removed after installation
+sys.path.insert(0, os.path.dirname(os.path.dirname(
+    os.path.dirname(os.path.abspath(__file__)))))
+
+import nngen as ng
+
+from veriloggen import *
+import veriloggen.thread as vthread
+import veriloggen.types.axi as axi
+
+
+def run(a_shape=(15, 15), b_shape=(15, 15),
+        a_dtype=ng.int32, b_dtype=ng.int32, c_dtype=ng.int32,
+        par=1, axi_datawidth=32, interrupt_name='irq', silent=False,
+        filename=None, simtype='iverilog', outputfile=None):
+
+    # create target hardware
+    a = ng.placeholder(a_dtype, shape=a_shape, name='a')
+    b = ng.placeholder(b_dtype, shape=b_shape, name='b')
+
+    d = ng.add(a, b, dtype=c_dtype, par=par)
+    e = ng.add(b, a, dtype=c_dtype, par=par)
+
+    # SW returns ng.add(x, y)
+    f = ng.extern([d, e], shape=a_shape, opcode=0x1,
+                  func=lambda x, y: x + y)
+    g = ng.sub(f, a)
+
+    # SW returns d as-is
+    h = ng.extern([g], shape=a_shape, opcode=0x2,
+                  func=lambda x: x)
+    c = ng.sub(h, b)
+
+    targ = ng.to_veriloggen([c], 'matrix_extern', silent=silent,
+                            config={'maxi_datawidth': axi_datawidth,
+                                    'interrupt_name': interrupt_name})
+
+    # verification data
+    va = np.arange(a.length, dtype=np.int64).reshape(a.shape) % [16]
+    vb = np.arange(b.length, dtype=np.int64).reshape(b.shape) % [32] + [16]
+
+    eval_outs = ng.eval([c], a=va, b=vb)
+    vc = eval_outs[0]
+
+    # to memory image
+    size_max = int(math.ceil(max(a.memory_size, b.memory_size, c.memory_size) / 4096)) * 4096
+    check_addr = max(a.addr, b.addr, c.addr) + size_max
+    size_check = size_max
+    tmp_addr = check_addr + size_check
+
+    memimg_datawidth = 32
+    mem = np.zeros([1024 * 1024 * 8 // (memimg_datawidth // 8)], dtype=np.int64)
+    mem = mem + [100]
+
+    axi.set_memory(mem, va, memimg_datawidth,
+                   a_dtype.width, a.addr,
+                   max(int(math.ceil(axi_datawidth / a_dtype.width)), par))
+    axi.set_memory(mem, vb, memimg_datawidth,
+                   b_dtype.width, b.addr,
+                   max(int(math.ceil(axi_datawidth / b_dtype.width)), par))
+    axi.set_memory(mem, vc, memimg_datawidth,
+                   c_dtype.width, check_addr,
+                   max(int(math.ceil(axi_datawidth / c_dtype.width)), par))
+
+    # test controller
+    m = Module('test')
+    params = m.copy_params(targ)
+    ports = m.copy_sim_ports(targ)
+    clk = ports['CLK']
+    resetn = ports['RESETN']
+    irq = ports[interrupt_name]
+    rst = m.Wire('RST')
+    rst.assign(Not(resetn))
+
+    # AXI memory model
+    if outputfile is None:
+        outputfile = os.path.splitext(os.path.basename(__file__))[0] + '.out'
+
+    memimg_name = 'memimg_' + outputfile
+
+    memory = axi.AxiMemoryModel(m, 'memory', clk, rst,
+                                datawidth=axi_datawidth,
+                                memimg_datawidth=memimg_datawidth,
+                                memimg=mem, memimg_name=memimg_name)
+    memory.connect(ports, 'maxi')
+
+    # AXI-Slave controller
+    _saxi = vthread.AXIMLite(m, '_saxi', clk, rst, noio=True)
+    _saxi.connect(ports, 'saxi')
+
+    # timer
+    time_counter = m.Reg('time_counter', 32, initval=0)
+    seq = Seq(m, 'seq', clk, rst)
+    seq(
+        time_counter.inc()
+    )
+
+    num_rep = functools.reduce(lambda x, y: x * y, c.shape[:-1], 1)
+
+    def ctrl():
+        for i in range(100):
+            pass
+
+        ng.sim.set_global_addrs(_saxi, tmp_addr)
+
+        araddr_irq_ier = ng.control_reg_interrupt_ier * 4
+        araddr_irq_isr = ng.control_reg_interrupt_isr * 4
+        araddr_irq_iar = ng.control_reg_interrupt_iar * 4
+        _saxi.write(araddr_irq_ier , 3) # irq enable
+
+        start_time = time_counter.value
+        ng.sim.start(_saxi)
+
+        print('# start')
+
+        # from extern-send
+        while irq == 0:
+            pass
+        irq_stat = _saxi.read(araddr_irq_isr)
+        if irq_stat != 2:
+            print('# Unexpected irq signal')
+            print('# verify: FAILED')
+            vthread.finish()
+        print('# irq stat = %d' % irq_stat)
+        _saxi.write(araddr_irq_iar , 2) # irq acknowledge: just irq stat ack_bit negation
+
+        # from extern-send
+        araddr = ng.control_reg_extern_send * 4
+        v = _saxi.read(araddr)
+
+        print('# opcode = %d' % v)
+
+        for i in range(num_rep):
+            for j in range(c.shape[-1]):
+                x_offset = tmp_addr - d.default_global_addr
+                y_offset = tmp_addr - e.default_global_addr
+                z_offset = tmp_addr - f.default_global_addr
+                x = memory.read_word(i * c.aligned_shape[-1] + j,
+                                     d.addr + x_offset, c_dtype.width)
+                y = memory.read_word(i * c.aligned_shape[-1] + j,
+                                     e.addr + y_offset, c_dtype.width)
+                z = x + y
+                memory.write_word(i * c.aligned_shape[-1] + j,
+                                  f.addr + z_offset, z, c_dtype.width)
+
+        # to extern-recv
+        awaddr = ng.control_reg_extern_recv * 4
+        _saxi.write(awaddr, 1)
+
+        # from extern-send
+        while irq == 0:
+            pass
+        irq_stat = _saxi.read(araddr_irq_isr)
+        if irq_stat != 2:
+            print('# Unexpected irq signal')
+            print('# verify: FAILED')
+            vthread.finish()
+        print('# irq stat = %d' % irq_stat)
+        _saxi.write(araddr_irq_iar , 0xff) # irq acknowledge: all of irq stat nagetion
+
+        # from extern-send
+        araddr = ng.control_reg_extern_send * 4
+        v = _saxi.read(araddr)
+
+        print('# opcode = %d' % v)
+
+        for i in range(num_rep):
+            for j in range(c.shape[-1]):
+                x_offset = tmp_addr - g.default_global_addr
+                z_offset = tmp_addr - h.default_global_addr
+                x = memory.read_word(i * c.aligned_shape[-1] + j,
+                                     g.addr + x_offset, c_dtype.width)
+                z = x
+                memory.write_word(i * c.aligned_shape[-1] + j,
+                                  h.addr + z_offset, z, c_dtype.width)
+
+        # to extern-recv
+        awaddr = ng.control_reg_extern_recv * 4
+        _saxi.write(awaddr, 1)
+
+        # from extern-send
+        while irq == 0:
+            pass
+        irq_stat = _saxi.read(araddr_irq_isr)
+        if irq_stat != 1:
+            print('# Unexpected irq signal')
+            print('# verify: FAILED')
+            vthread.finish()
+        print('# irq stat = %d' % irq_stat)
+        _saxi.write(araddr_irq_iar, 1) # irq acknowledge: irq stat busy_bit negation
+
+        #ng.sim.wait(_saxi)
+        end_time = time_counter.value
+
+        print('# end')
+        print('# execution cycles: %d' % (end_time - start_time))
+
+        for i in range(100):
+            pass
+
+        # verify
+        ok = True
+        for i in range(num_rep):
+            for j in range(c.shape[-1]):
+                orig = memory.read_word(i * c.aligned_shape[-1] + j,
+                                        c.addr, c_dtype.width)
+                check = memory.read_word(i * c.aligned_shape[-1] + j,
+                                         check_addr, c_dtype.width)
+
+                if vthread.verilog.NotEql(orig, check):
+                    print('NG', i, j, orig, check)
+                    ok = False
+                # else:
+                #    print('OK', i, j, orig, check)
+
+        if ok:
+            print('# verify: PASSED')
+        else:
+            print('# verify: FAILED')
+
+        vthread.finish()
+
+    th = vthread.Thread(m, 'th_ctrl', clk, rst, ctrl)
+    fsm = th.start()
+
+    uut = m.Instance(targ, 'uut',
+                     params=m.connect_params(targ),
+                     ports=m.connect_ports(targ))
+
+    # simulation.setup_waveform(m, uut)
+    simulation.setup_clock(m, clk, hperiod=5)
+    init = simulation.setup_reset(m, resetn, m.make_reset(), period=100, polarity='low')
+
+    init.add(
+        Delay(1000000),
+        Systask('finish'),
+    )
+
+    # output source code
+    if filename is not None:
+        m.to_verilog(filename)
+
+    # run simulation
+    sim = simulation.Simulator(m, sim=simtype)
+    rslt = sim.run(outputfile=outputfile)
+    lines = rslt.splitlines()
+    if simtype == 'verilator' and lines[-1].startswith('-'):
+        rslt = '\n'.join(lines[:-1])
+    return rslt
+
+
+if __name__ == '__main__':
+    rslt = run(silent=False, filename='tmp.v')
+    print(rslt)

--- a/tests/matrix_extern_irq/test_matrix_extern_irq_int32.py
+++ b/tests/matrix_extern_irq/test_matrix_extern_irq_int32.py
@@ -1,0 +1,50 @@
+from __future__ import absolute_import
+from __future__ import print_function
+
+import os
+import sys
+
+# the next line can be removed after installation
+sys.path.insert(0, os.path.dirname(os.path.dirname(
+    os.path.dirname(os.path.abspath(__file__)))))
+
+import nngen as ng
+import veriloggen
+
+import matrix_extern_irq
+
+
+#a_shape = (15, 15)
+#b_shape = (15, 15)
+a_shape = (1, 8)
+b_shape = (1, 8)
+a_dtype = ng.int32
+b_dtype = ng.int32
+c_dtype = ng.int32
+par = 1
+axi_datawidth = 32
+interrupt_name = 'IRQ'
+
+
+def test(request, silent=True):
+    veriloggen.reset()
+
+    simtype = request.config.getoption('--sim')
+
+    rslt = matrix_extern_irq.run(a_shape, b_shape,
+                             a_dtype, b_dtype, c_dtype,
+                             par, axi_datawidth, interrupt_name, silent,
+                             filename=None, simtype=simtype,
+                             outputfile=os.path.splitext(os.path.basename(__file__))[0] + '.out')
+
+    verify_rslt = rslt.splitlines()[-1]
+    assert(verify_rslt == '# verify: PASSED')
+
+
+if __name__ == '__main__':
+    rslt = matrix_extern_irq.run(a_shape, b_shape,
+                             a_dtype, b_dtype, c_dtype,
+                             par, axi_datawidth, interrupt_name, silent=False,
+                             filename='tmp.v',
+                             outputfile=os.path.splitext(os.path.basename(__file__))[0] + '.out')
+    print(rslt)

--- a/tests/matrix_extern_irq_reset/Makefile
+++ b/tests/matrix_extern_irq_reset/Makefile
@@ -1,0 +1,30 @@
+TARGET=$(shell ls *.py | grep -v test | grep -v parsetab.py)
+ARGS=
+
+PYTHON=python3
+#PYTHON=python
+#OPT=-m pdb
+#OPT=-m cProfile -s time
+#OPT=-m cProfile -o profile.rslt
+SIMTYPE=iverilog
+
+.PHONY: all
+all: test
+
+.PHONY: run
+run:
+	$(PYTHON) $(OPT) $(TARGET) $(ARGS)
+
+.PHONY: test
+test:
+	$(PYTHON) -m pytest -vv --sim $(SIMTYPE)
+
+.PHONY: check
+check:
+	$(PYTHON) $(OPT) $(TARGET) $(ARGS) > tmp.v
+	iverilog -tnull -Wall tmp.v
+	rm -f tmp.v
+
+.PHONY: clean
+clean:
+	rm -rf *.pyc __pycache__ parsetab.py .cache *.out *.png *.dot tmp.v uut.vcd

--- a/tests/matrix_extern_irq_reset/matrix_extern_irq_reset.py
+++ b/tests/matrix_extern_irq_reset/matrix_extern_irq_reset.py
@@ -1,0 +1,406 @@
+from __future__ import absolute_import
+from __future__ import print_function
+
+import os
+import sys
+import functools
+import math
+import numpy as np
+
+if sys.version_info.major < 3:
+    from itertools import izip_longest as zip_longest
+else:
+    from itertools import zip_longest
+
+# the next line can be removed after installation
+sys.path.insert(0, os.path.dirname(os.path.dirname(
+    os.path.dirname(os.path.abspath(__file__)))))
+
+import nngen as ng
+
+from veriloggen import *
+import veriloggen.thread as vthread
+import veriloggen.types.axi as axi
+
+
+def run(a_shape=(15, 15), b_shape=(15, 15),
+        a_dtype=ng.int32, b_dtype=ng.int32, c_dtype=ng.int32,
+        par=1, axi_datawidth=32, interrupt_name='irq', silent=False,
+        filename=None, simtype='iverilog', outputfile=None):
+
+    # create target hardware
+    a = ng.placeholder(a_dtype, shape=a_shape, name='a')
+    b = ng.placeholder(b_dtype, shape=b_shape, name='b')
+
+    d = ng.add(a, b, dtype=c_dtype, par=par)
+    e = ng.add(b, a, dtype=c_dtype, par=par)
+
+    # SW returns ng.add(x, y)
+    f = ng.extern([d, e], shape=a_shape, opcode=0x1,
+                  func=lambda x, y: x + y)
+    g = ng.sub(f, a)
+
+    # SW returns d as-is
+    h = ng.extern([g], shape=a_shape, opcode=0x2,
+                  func=lambda x: x)
+    c = ng.sub(h, b)
+
+    targ = ng.to_veriloggen([c], 'matrix_extern', silent=silent,
+                            config={'maxi_datawidth': axi_datawidth,
+                                    'interrupt_name': interrupt_name})
+
+    # verification data
+    va = np.arange(a.length, dtype=np.int64).reshape(a.shape) % [16]
+    vb = np.arange(b.length, dtype=np.int64).reshape(b.shape) % [32] + [16]
+
+    eval_outs = ng.eval([c], a=va, b=vb)
+    vc = eval_outs[0]
+
+    # to memory image
+    size_max = int(math.ceil(max(a.memory_size, b.memory_size, c.memory_size) / 4096)) * 4096
+    check_addr = max(a.addr, b.addr, c.addr) + size_max
+    size_check = size_max
+    tmp_addr = check_addr + size_check
+
+    memimg_datawidth = 32
+    mem = np.zeros([1024 * 1024 * 8 // (memimg_datawidth // 8)], dtype=np.int64)
+    mem = mem + [100]
+
+    axi.set_memory(mem, va, memimg_datawidth,
+                   a_dtype.width, a.addr,
+                   max(int(math.ceil(axi_datawidth / a_dtype.width)), par))
+    axi.set_memory(mem, vb, memimg_datawidth,
+                   b_dtype.width, b.addr,
+                   max(int(math.ceil(axi_datawidth / b_dtype.width)), par))
+    axi.set_memory(mem, vc, memimg_datawidth,
+                   c_dtype.width, check_addr,
+                   max(int(math.ceil(axi_datawidth / c_dtype.width)), par))
+
+    # test controller
+    m = Module('test')
+    params = m.copy_params(targ)
+    ports = m.copy_sim_ports(targ)
+    clk = ports['CLK']
+    resetn = ports['RESETN']
+    irq = ports[interrupt_name]
+    rst = m.Wire('RST')
+    rst.assign(Not(resetn))
+
+    # AXI memory model
+    if outputfile is None:
+        outputfile = os.path.splitext(os.path.basename(__file__))[0] + '.out'
+
+    memimg_name = 'memimg_' + outputfile
+
+    memory = axi.AxiMemoryModel(m, 'memory', clk, rst,
+                                datawidth=axi_datawidth,
+                                memimg_datawidth=memimg_datawidth,
+                                memimg=mem, memimg_name=memimg_name)
+    memory.connect(ports, 'maxi')
+
+    # AXI-Slave controller
+    _saxi = vthread.AXIMLite(m, '_saxi', clk, rst, noio=True)
+    _saxi.connect(ports, 'saxi')
+
+    # timer
+    time_counter = m.Reg('time_counter', 32, initval=0)
+    seq = Seq(m, 'seq', clk, rst)
+    seq(
+        time_counter.inc()
+    )
+
+    num_rep = functools.reduce(lambda x, y: x * y, c.shape[:-1], 1)
+
+    def irq_join(saxi, irq_bit):
+        while irq == 0:
+            pass
+        araddr = ng.control_reg_interrupt_isr * 4
+        irq_stat = saxi.read(araddr)
+
+        if irq_stat != irq_bit:
+            print('# Unexpected irq signal: %d' % irq_stat)
+            print('# verify: FAILED')
+            vthread.finish()
+
+        print('# irq stat = %d' % irq_stat)
+        awaddr = ng.control_reg_interrupt_iar * 4
+        saxi.write(awaddr, irq_bit)
+
+    def ctrl():
+        for i in range(100):
+            pass
+
+        ng.sim.set_global_addrs(_saxi, tmp_addr)
+
+        araddr_ext_snd = ng.control_reg_extern_send * 4
+        awaddr_ext_rcv = ng.control_reg_extern_recv * 4
+        awaddr_irq_ier = ng.control_reg_interrupt_ier * 4
+        araddr_irq_isr = ng.control_reg_interrupt_isr * 4
+        awaddr_irq_iar = ng.control_reg_interrupt_iar * 4
+        _saxi.write(awaddr_irq_ier , 3) # irq enable
+
+        ng.sim.sw_rst(_saxi)
+
+        print('# 0st software reset (during idle)')
+
+        for i in range(100):
+            pass
+
+        irq_stat = _saxi.read(araddr_irq_isr)
+        if irq_stat != 0:
+            print('# Unexpected irq signal: %d' % irq_stat)
+            print('# verify: FAILED')
+            vthread.finish()
+        print('# irq stat = %d' % irq_stat)  # no irq busy by software reset when idle
+
+        start_time = time_counter.value
+        ng.sim.start(_saxi)
+
+        print('# 1st test start')
+
+        # from extern-send
+        irq_join(_saxi, 2)
+        v = _saxi.read(araddr_ext_snd)
+        print('# opcode = %d' % v)
+
+        for i in range(num_rep):
+            for j in range(c.shape[-1]):
+                x_offset = tmp_addr - d.default_global_addr
+                y_offset = tmp_addr - e.default_global_addr
+                z_offset = tmp_addr - f.default_global_addr
+                x = memory.read_word(i * c.aligned_shape[-1] + j,
+                                     d.addr + x_offset, c_dtype.width)
+                y = memory.read_word(i * c.aligned_shape[-1] + j,
+                                     e.addr + y_offset, c_dtype.width)
+                z = x + y
+                memory.write_word(i * c.aligned_shape[-1] + j,
+                                  f.addr + z_offset, z, c_dtype.width)
+
+        # to extern-recv
+        _saxi.write(awaddr_ext_rcv, 1)
+
+        # from extern-send
+        irq_join(_saxi, 2)
+        v = _saxi.read(araddr_ext_snd)
+        print('# opcode = %d' % v)
+
+        # software reset
+        ng.sim.sw_rst(_saxi)
+
+        print('# 1st software reset (before resume)')
+
+        # from extern-send
+        irq_join(_saxi, 1)
+
+        # restart
+        ng.sim.start(_saxi)
+
+        print('# Restart')
+
+        # from extern-send
+        irq_join(_saxi, 2)
+        v = _saxi.read(araddr_ext_snd)
+        print('# opcode = %d' % v)
+
+        for i in range(num_rep):
+            for j in range(c.shape[-1]):
+                x_offset = tmp_addr - d.default_global_addr
+                y_offset = tmp_addr - e.default_global_addr
+                z_offset = tmp_addr - f.default_global_addr
+                x = memory.read_word(i * c.aligned_shape[-1] + j,
+                                     d.addr + x_offset, c_dtype.width)
+                y = memory.read_word(i * c.aligned_shape[-1] + j,
+                                     e.addr + y_offset, c_dtype.width)
+                z = x + y
+                memory.write_word(i * c.aligned_shape[-1] + j,
+                                  f.addr + z_offset, z, c_dtype.width)
+
+        # to extern-recv
+        _saxi.write(awaddr_ext_rcv, 1)
+
+        # from extern-send
+        irq_join(_saxi, 2)
+        v = _saxi.read(araddr_ext_snd)
+        print('# opcode = %d' % v)
+
+        for i in range(num_rep):
+            for j in range(c.shape[-1]):
+                x_offset = tmp_addr - g.default_global_addr
+                z_offset = tmp_addr - h.default_global_addr
+                x = memory.read_word(i * c.aligned_shape[-1] + j,
+                                     g.addr + x_offset, c_dtype.width)
+                z = x
+                memory.write_word(i * c.aligned_shape[-1] + j,
+                                  h.addr + z_offset, z, c_dtype.width)
+
+        # to extern-recv
+        _saxi.write(awaddr_ext_rcv, 1)
+
+        # from extern-send
+
+        irq_join(_saxi, 1)
+        #ng.sim.wait(_saxi)
+        end_time = time_counter.value
+
+        print('# end')
+        print('# execution cycles: %d' % (end_time - start_time))
+
+        # verify
+        ok_1st = True
+        for i in range(num_rep):
+            for j in range(c.shape[-1]):
+                orig = memory.read_word(i * c.aligned_shape[-1] + j,
+                                        c.addr, c_dtype.width)
+                check = memory.read_word(i * c.aligned_shape[-1] + j,
+                                         check_addr, c_dtype.width)
+
+                if vthread.verilog.NotEql(orig, check):
+                    print('NG', i, j, orig, check)
+                    ok_1st = False
+                # else:
+                #    print('OK', i, j, orig, check)
+
+        # 2nd test
+
+        # start
+        start_time = time_counter.value
+        ng.sim.start(_saxi)
+
+        print('# 2nd test start')
+
+        # from extern-send
+        irq_join(_saxi, 2)
+        v = _saxi.read(araddr_ext_snd)
+        print('# opcode = %d' % v)
+
+        for i in range(num_rep):
+            for j in range(c.shape[-1]):
+                x_offset = tmp_addr - d.default_global_addr
+                y_offset = tmp_addr - e.default_global_addr
+                z_offset = tmp_addr - f.default_global_addr
+                x = memory.read_word(i * c.aligned_shape[-1] + j,
+                                     d.addr + x_offset, c_dtype.width)
+                y = memory.read_word(i * c.aligned_shape[-1] + j,
+                                     e.addr + y_offset, c_dtype.width)
+                z = x + y
+                memory.write_word(i * c.aligned_shape[-1] + j,
+                                  f.addr + z_offset, z, c_dtype.width)
+
+        # to extern-recv
+        _saxi.write(awaddr_ext_rcv, 1)
+
+        while (memory.waddr.awvalid) == 0:
+            pass
+
+        ng.sim.sw_rst(_saxi)
+
+        print('# 2nd software reset (during Master AXI transaction)')
+
+        irq_join(_saxi, 1) # irq busy by software reset
+
+        # restart
+        ng.sim.start(_saxi)
+
+        print('# Restart')
+
+        # from extern-send
+        irq_join(_saxi, 2)
+        araddr = ng.control_reg_extern_send * 4
+        print('# opcode = %d' % v)
+
+        for i in range(num_rep):
+            for j in range(c.shape[-1]):
+                x_offset = tmp_addr - d.default_global_addr
+                y_offset = tmp_addr - e.default_global_addr
+                z_offset = tmp_addr - f.default_global_addr
+                x = memory.read_word(i * c.aligned_shape[-1] + j,
+                                     d.addr + x_offset, c_dtype.width)
+                y = memory.read_word(i * c.aligned_shape[-1] + j,
+                                     e.addr + y_offset, c_dtype.width)
+                z = x + y
+                memory.write_word(i * c.aligned_shape[-1] + j,
+                                  f.addr + z_offset, z, c_dtype.width)
+
+        # to extern-recv
+        _saxi.write(awaddr_ext_rcv, 1)
+
+        # from extern-send
+        irq_join(_saxi, 2)
+        v = _saxi.read(araddr_ext_snd)
+        print('# opcode = %d' % v)
+
+        for i in range(num_rep):
+            for j in range(c.shape[-1]):
+                x_offset = tmp_addr - g.default_global_addr
+                z_offset = tmp_addr - h.default_global_addr
+                x = memory.read_word(i * c.aligned_shape[-1] + j,
+                                     g.addr + x_offset, c_dtype.width)
+                z = x
+                memory.write_word(i * c.aligned_shape[-1] + j,
+                                  h.addr + z_offset, z, c_dtype.width)
+
+        # to extern-recv
+        _saxi.write(awaddr_ext_rcv, 1)
+
+        # termination
+        irq_join(_saxi, 1)
+        #ng.sim.wait(_saxi)
+        end_time = time_counter.value
+
+        print('# end')
+        print('# execution cycles: %d' % (end_time - start_time))
+
+        # verify
+        ok_2nd = True
+        for i in range(num_rep):
+            for j in range(c.shape[-1]):
+                orig = memory.read_word(i * c.aligned_shape[-1] + j,
+                                        c.addr, c_dtype.width)
+                check = memory.read_word(i * c.aligned_shape[-1] + j,
+                                         check_addr, c_dtype.width)
+
+                if vthread.verilog.NotEql(orig, check):
+                    print('NG', i, j, orig, check)
+                    ok_2nd = False
+                # else:
+                #    print('OK', i, j, orig, check)
+
+        if ok_1st and ok_2nd:
+            print('# verify: PASSED')
+        else:
+            print('# verify: FAILED')
+
+        vthread.finish()
+
+    th = vthread.Thread(m, 'th_ctrl', clk, rst, ctrl)
+    fsm = th.start()
+
+    uut = m.Instance(targ, 'uut',
+                     params=m.connect_params(targ),
+                     ports=m.connect_ports(targ))
+
+    # simulation.setup_waveform(m, uut)
+    simulation.setup_clock(m, clk, hperiod=5)
+    init = simulation.setup_reset(m, resetn, m.make_reset(), period=100, polarity='low')
+
+    init.add(
+        Delay(1000000),
+        Systask('finish'),
+    )
+
+    # output source code
+    if filename is not None:
+        m.to_verilog(filename)
+
+    # run simulation
+    sim = simulation.Simulator(m, sim=simtype)
+    rslt = sim.run(outputfile=outputfile)
+    lines = rslt.splitlines()
+    if simtype == 'verilator' and lines[-1].startswith('-'):
+        rslt = '\n'.join(lines[:-1])
+    return rslt
+
+
+if __name__ == '__main__':
+    rslt = run(silent=False, filename='tmp.v')
+    print(rslt)

--- a/tests/matrix_extern_irq_reset/test_matrix_extern_irq_reset_int32.py
+++ b/tests/matrix_extern_irq_reset/test_matrix_extern_irq_reset_int32.py
@@ -1,0 +1,50 @@
+from __future__ import absolute_import
+from __future__ import print_function
+
+import os
+import sys
+
+# the next line can be removed after installation
+sys.path.insert(0, os.path.dirname(os.path.dirname(
+    os.path.dirname(os.path.abspath(__file__)))))
+
+import nngen as ng
+import veriloggen
+
+import matrix_extern_irq_reset
+
+
+#a_shape = (15, 15)
+#b_shape = (15, 15)
+a_shape = (1, 8)
+b_shape = (1, 8)
+a_dtype = ng.int32
+b_dtype = ng.int32
+c_dtype = ng.int32
+par = 1
+axi_datawidth = 32
+interrupt_name = 'IRQ'
+
+
+def test(request, silent=True):
+    veriloggen.reset()
+
+    simtype = request.config.getoption('--sim')
+
+    rslt = matrix_extern_irq_reset.run(a_shape, b_shape,
+                             a_dtype, b_dtype, c_dtype,
+                             par, axi_datawidth, interrupt_name, silent,
+                             filename=None, simtype=simtype,
+                             outputfile=os.path.splitext(os.path.basename(__file__))[0] + '.out')
+
+    verify_rslt = rslt.splitlines()[-1]
+    assert(verify_rslt == '# verify: PASSED')
+
+
+if __name__ == '__main__':
+    rslt = matrix_extern_irq_reset.run(a_shape, b_shape,
+                             a_dtype, b_dtype, c_dtype,
+                             par, axi_datawidth, interrupt_name, silent=False,
+                             filename='tmp.v',
+                             outputfile=os.path.splitext(os.path.basename(__file__))[0] + '.out')
+    print(rslt)


### PR DESCRIPTION
概要
====
割込み機能を実装しました．
※ **レジスタマップに変更があります**

実装のポイント
-------
+ 動作確認用のテスト追加
    - tests/matrix_extern_irq
    - tests/matrix_extern_irq_reset
+ default_configに設定項目追加
    - interrupt_enable (default: true)
    - falseに設定した場合，下記の割込み用レジスタはreservedになる
+ レジスタマップ
    - reserved 空間を追加
    - 追加した割込み信号の挙動はXilinx AXI Interrupt Controllerに準拠
        - isr (interrupt status register)
        - ier (interrupt enable register)
        - iar (interrupt acknowledge register)
    - 各ビットフィールドの持つ意味
        - bit 0 (LSB): busy 信号が0になった 
        - bit 1: extern が sendされた
        - MSB - bit 2: reserved

+ 割込み信号のモードはエッジセンシティブのみ
    - isrのいずれかのビットフィールドがHiになっている場合，irq信号もHiのまま
    - iarにネゲートしたいビットフィールドに対応する値をwriteすることによりisrをクリアする

```
[Register Map]
    0 (R ): header0 (default: 0)
    4 (R ): header1 (default: 0)
    8 (R ): header2 (default: 0)
   12 (R ): header3 (default: 0)
   16 ( W): Start (set '1' to run)
   20 (R ): Busy (returns '1' when running)
   24 ( W): Reset (set '1' to initialize internal logic)
   28 (R ): Opcode from extern objects to SW (returns '0' when idle)
   32 ( W): Resume extern objects (set '1' to resume)
   36 (R ): Interrupt Status Register
   40 ( W): Interrupt Enable Register
   44 ( W): Interrupt Acknowledge Register
   48 (X): reserved ..
  124 (X): .. reserved
  128 (RW): Global address offset (default: 0)
  132 (RW): Address of temporal storages (size: 97KB)
  136 (RW): Address of output (matmul) 'output_layer' (size: 64B, dtype: int8, shape: (1, 10), alignment: 4 words (4 bytes)), aligned shape: (1, 12)
  140 (RW): Address of placeholder 'input_layer' (size: 4KB, dtype: int8, shape: (1, 32, 32, 3), alignment: 4 words (4 bytes)), aligned shape: (1, 32, 32, 4)
  144 (RW): Address of variables 'w0', 'b0', 's0', 'w1', 'b1', 's1', 'w2', 'b2', 's2', 'w3', 'b3', 's3' (size: 4139KB)
```