### PR TITLE
Fix rounding related to conv2d, leaky_relu and avg_pool

### DIFF
--- a/nngen/operator/conv2d.py
+++ b/nngen/operator/conv2d.py
@@ -968,7 +968,7 @@ class conv2d(bt._Operator):
                           (sum_width, sum_point, sum_signed,
                            sum_width, sum_point, sum_signed))] *
                         self.par_och * self.par_col * self.par_row)
-        substrms.extend([('mul_rshift_clip',
+        substrms.extend([('mul_rshift_round_clip',
                           (sum_width, sum_point, sum_signed,
                            scale_width, scale_point, scale_signed,
                            scl_width, scl_point, scl_signed,

--- a/nngen/operator/leaky_relu.py
+++ b/nngen/operator/leaky_relu.py
@@ -69,7 +69,7 @@ def get_leaky_relu_op(slope, rshift=None, dtype=None):
         slope_width = int(math.ceil(math.log(slope, 2)) + 1) + 1  # signed
         dtype_width = dtype.width if dtype is not None else 32
         mul.width = slope_width + dtype_width
-        neg = strm.Sra(mul, rshift)
+        neg = strm.SraRound(mul, rshift)
         neg.width = dtype_width
         return strm.Mux(args[0] > strm.Int(0), args[0], neg)
 

--- a/nngen/operator/pool.py
+++ b/nngen/operator/pool.py
@@ -1105,15 +1105,14 @@ class avg_pool(_pool):
         x_point = act.get_op_point()
         x_signed = act.get_signed()
 
-        # +1 port for rounding
         substrms = [('add_tree_rshift_round',
-                     (x_datawidth, x_point, x_signed, num_vars + 1))] * self.par
+                     (x_datawidth, x_point, x_signed, num_vars))] * self.par
 
         if self.force_div or num_vars & (num_vars - 1) != 0:
             y_datawidth = max(num_vars.bit_length() + 1, 2)
             y_point = 0
             y_signed = True
-            substrms.extend([('div_const',
+            substrms.extend([('div_const_frac',
                               (x_datawidth, x_point, x_signed,
                                y_datawidth, y_point, y_signed))] * self.par)
 
@@ -1141,17 +1140,17 @@ class avg_pool(_pool):
 
         if self.force_div or num_vars & (num_vars - 1) != 0:
             addtree.to_constant('rshift', 0)
-            # for rounding
-            addtree.to_source('var%d' % (i + 1), num_vars // 2)
             div = strm.substream(self.substreams[self.par + index])
+
+            frac = num_vars//2
+            div.to_constant('frac', frac)
+
             div.to_source('x', sum)
             div.to_constant('y', num_vars)
             return div.from_sink('z')
 
         rshift = int(math.log(num_vars, 2))
         addtree.to_constant('rshift', rshift)
-        # for rounding
-        addtree.to_source('var%d' % (i + 1), 0)
 
         return sum
 

--- a/nngen/operator/pool_serial.py
+++ b/nngen/operator/pool_serial.py
@@ -871,7 +871,7 @@ class avg_pool_serial(_pool_serial):
         x_point = act.get_op_point()
         x_signed = act.get_signed()
 
-        substrms = [('acc_rshift_round_frac',
+        substrms = [('acc_rshift_round',
                      (x_datawidth, x_point, x_signed,
                       x_datawidth, x_point, x_signed))] * self.par
 
@@ -879,7 +879,7 @@ class avg_pool_serial(_pool_serial):
             y_datawidth = max(num_vars.bit_length() + 1, 2)
             y_point = 0
             y_signed = True
-            substrms.extend([('div_const',
+            substrms.extend([('div_const_frac',
                               (x_datawidth, x_point, x_signed,
                                y_datawidth, y_point, y_signed))] * self.par)
 
@@ -904,11 +904,13 @@ class avg_pool_serial(_pool_serial):
         if self.force_div or num_vars & (num_vars - 1) != 0:
             rshift = 0
             acc.to_constant('rshift', rshift)
-            sum += (num_vars // 2)
+            #sum += (num_vars // 2)
 
             div = strm.substream(self.substreams[self.par + index])
             div.to_source('x', sum)
             div.to_constant('y', num_vars)
+            frac = num_vars//2
+            div.to_constant('frac', frac)
 
             return div.from_sink('z'), valid
 

--- a/nngen/operator/pool_serial.py
+++ b/nngen/operator/pool_serial.py
@@ -904,7 +904,6 @@ class avg_pool_serial(_pool_serial):
         if self.force_div or num_vars & (num_vars - 1) != 0:
             rshift = 0
             acc.to_constant('rshift', rshift)
-            #sum += (num_vars // 2)
 
             div = strm.substream(self.substreams[self.par + index])
             div.to_source('x', sum)

--- a/nngen/substreams.py
+++ b/nngen/substreams.py
@@ -214,6 +214,12 @@ def mul_rshift_round_madd(m, clk, rst,
 
     frac = stream.Mux(rshift > 0, stream.Sll(1, rshift - 1), 0)
     frac.width = mul_width
+    neg_frac = stream.Uminus(frac)
+    neg_frac.width = datawidth
+    neg_frac.latency = 0
+    frac = stream.Mux(x >= 0, frac, neg_frac)
+    frac.latency = 0
+    frac.width = datawidth
 
     z = stream.Madd(x, y, frac)
     z.latency = 4
@@ -733,11 +739,11 @@ def div_const_frac(m, clk, rst,
     frac= stream.source('frac')
     frac.width = datawidth
 
-    frac_minus = stream.Uminus(frac)
-    frac_minus.width = datawidth
-    frac_minus.latency = 0
+    neg_frac = stream.Uminus(frac)
+    neg_frac.width = datawidth
+    neg_frac.latency = 0
 
-    frac = stream.Mux(x >= 0, frac, frac_minus)
+    frac = stream.Mux(x >= 0, frac, neg_frac)
     frac.latency = 0
     frac.width = datawidth
 

--- a/nngen/substreams.py
+++ b/nngen/substreams.py
@@ -151,6 +151,52 @@ def mul_rshift_round(m, clk, rst,
     return stream
 
 
+def mul_rshift_round_clip(m, clk, rst,
+                          x_datawidth, x_point, x_signed,
+                          y_datawidth, y_point, y_signed,
+                          mul_width=None, mul_point=None, mul_signed=None,
+                          out_width=None, out_point=None, out_signed=None):
+
+    name = _tmp_name('mul_rshift_round_clip')
+    datawidth = max(x_datawidth, y_datawidth)
+    point = max(x_point, y_point)
+
+    stream = vthread.Stream(m, name, clk, rst, datawidth)
+    x = stream.source('x', x_datawidth, x_point, x_signed)
+    y = stream.source('y', y_datawidth, y_point, y_signed)
+    rshift = stream.source('rshift', signed=False)
+    rshift.width = int(math.ceil(math.log(datawidth, 2))) + 1
+
+    z = x * y
+    z.latency = 4
+    if mul_width is not None:
+        z.width = mul_width
+    if mul_signed is not None:
+        z.signed = mul_signed
+    if mul_point is not None and point != mul_point:
+        z = stream.Cast(z, point=mul_point)
+    z = stream.SraRound(z, rshift)
+
+    p_th = (1 << (out_width - 1)) - 1
+    n_th = -1 * p_th
+    p_th = p_th >> out_point
+    n_th = n_th >> out_point
+
+    p = stream.Mux(z > p_th, p_th, z)
+    n = stream.Mux(z < n_th, n_th, z)
+    z = stream.Mux(z >= 0, p, n)
+
+    if out_width is not None:
+        z.width = out_width
+    if out_signed is not None:
+        z.signed = out_signed
+    if out_point is not None and z.point != out_point:
+        z = stream.Cast(z, point=out_point)
+
+    stream.sink(z, 'z')
+    return stream
+
+
 def mul_rshift_round_madd(m, clk, rst,
                           x_datawidth, x_point, x_signed,
                           y_datawidth, y_point, y_signed,
@@ -660,6 +706,44 @@ def div_const(m, clk, rst,
     y = stream.source('y', y_datawidth, y_point, y_signed)
 
     z = stream.Div(x, y)
+    if div_width is not None:
+        z.width = div_width
+    if div_signed is not None:
+        z.signed = div_signed
+    if div_point is not None and point != div_point:
+        z = stream.Cast(z, point=div_point)
+
+    stream.sink(z, 'z')
+    return stream
+
+
+def div_const_frac(m, clk, rst,
+              x_datawidth, x_point, x_signed,
+              y_datawidth, y_point, y_signed,
+              div_width=None, div_point=None, div_signed=None):
+
+    name = _tmp_name('div_const_frac')
+    datawidth = max(x_datawidth, y_datawidth)
+    point = max(x_point, y_point)
+
+    stream = vthread.Stream(m, name, clk, rst, datawidth)
+    x = stream.source('x', x_datawidth, x_point, x_signed)
+    y = stream.source('y', y_datawidth, y_point, y_signed)
+
+    frac= stream.source('frac')
+    frac.width = datawidth
+
+    frac_minus = stream.Uminus(frac)
+    frac_minus.width = datawidth
+    frac_minus.latency = 0
+
+    frac = stream.Mux(x >= 0, frac, frac_minus)
+    frac.latency = 0
+    frac.width = datawidth
+
+    x_frac = stream.Add(x, frac)
+    x_frac.latency = 0
+    z = stream.Div(x_frac, y)
     if div_width is not None:
         z.width = div_width
     if div_signed is not None:

--- a/nngen/verify/conv2d.py
+++ b/nngen/verify/conv2d.py
@@ -202,8 +202,8 @@ def conv2d(input, filter, strides,
 
     def my_matmul_by_multiply(a, w):
         mul = np.multiply(a, w)
-        mul = np.right_shift(mul, mul_shift)
         mul = np.add(mul, rshift_mul_round.reshape([rshift_mul_round.shape[-1], 1]))
+        mul = np.right_shift(mul, mul_shift)
         mul = np.right_shift(mul, rshift_mul.reshape([rshift_mul.shape[-1], 1]))
         return np.add.reduce(mul, axis=1)
 
@@ -239,7 +239,8 @@ def conv2d(input, filter, strides,
                 sum = np.right_shift(sum, rshift_sum)
                 sum = np.add(sum, shifted_bias)
                 sum = np.multiply(sum, shifted_scale)
-                sum = np.add(sum, rshift_out_round)
+                frac = np.where(sum>=0, rshift_out_round, rshift_out_round - 1)
+                sum = np.add(sum,frac)
                 sum = np.right_shift(sum, rshift_out)
                 sum = np.where(sum > p_th, p_th, np.where(sum < n_th, n_th, sum))
 

--- a/nngen/verify/conv2d.py
+++ b/nngen/verify/conv2d.py
@@ -239,7 +239,8 @@ def conv2d(input, filter, strides,
                 sum = np.right_shift(sum, rshift_sum)
                 sum = np.add(sum, shifted_bias)
                 sum = np.multiply(sum, shifted_scale)
-                frac = np.where(sum>=0, rshift_out_round, rshift_out_round - 1)
+                frac = np.where(rshift_out!=0, np.where(sum>=0, rshift_out_round, rshift_out_round - 1),
+                        np.zeros_like(rshift_out, dtype=np.int64))
                 sum = np.add(sum,frac)
                 sum = np.right_shift(sum, rshift_out)
                 sum = np.where(sum > p_th, p_th, np.where(sum < n_th, n_th, sum))

--- a/nngen/verify/conv2d.py
+++ b/nngen/verify/conv2d.py
@@ -163,6 +163,14 @@ def conv2d(input, filter, strides,
                                          rshift_sum_pow),
                                 np.zeros_like(rshift_sum, dtype=np.int64))
 
+    rshift_out_pow = np.where(rshift_out > np.zeros_like(rshift_out, dtype=np.int64),
+                              rshift_out - 1,
+                              np.zeros_like(rshift_out))
+    rshift_out_round = np.where(rshift_out > np.zeros_like(rshift_out, dtype=np.int64),
+                                np.power(np.ones_like(rshift_out, dtype=np.int64) * 2,
+                                         rshift_out_pow),
+                                np.zeros_like(rshift_out, dtype=np.int64))
+
     input_point = 0 if input_dtype is None else input_dtype.point
     filter_point = 0 if filter_dtype is None else filter_dtype.point
     bias_point = 0 if bias_dtype is None else bias_dtype.point
@@ -231,6 +239,7 @@ def conv2d(input, filter, strides,
                 sum = np.right_shift(sum, rshift_sum)
                 sum = np.add(sum, shifted_bias)
                 sum = np.multiply(sum, shifted_scale)
+                sum = np.add(sum, rshift_out_round)
                 sum = np.right_shift(sum, rshift_out)
                 sum = np.where(sum > p_th, p_th, np.where(sum < n_th, n_th, sum))
 

--- a/nngen/verify/leaky_relu.py
+++ b/nngen/verify/leaky_relu.py
@@ -4,6 +4,7 @@ from __future__ import division
 
 import numpy as np
 import functools
+from decimal import Decimal, ROUND_HALF_UP, ROUND_HALF_EVEN
 
 
 def leaky_relu(features, slope, rshift, dtype=None, name=None, par=1,
@@ -16,7 +17,10 @@ def leaky_relu(features, slope, rshift, dtype=None, name=None, par=1,
     out_point = 0 if dtype is None else dtype.point
     out_shift = out_point - features_point
 
-    negs = (features * slope) >> rshift
+    features_shape = features.shape
+    negs = np.array(list(map(lambda x: Decimal(str(x*slope/(2**rshift))).quantize(Decimal('0'),
+                rounding=ROUND_HALF_UP), features.flatten()))).astype(np.int64).reshape(features_shape)
+
     comp = features >= 0
 
     out_op = ((lambda x: x << out_shift) if out_shift >= 0 else


### PR DESCRIPTION
Abstract
=========
Current rounding operation isn't commonly used.  This changes will make rounding on conv2d, leaky_relu(negative_slope part) and avg_pool to correspond to ["Round half away from zero"](https://en.wikipedia.org/wiki/Rounding#Round_half_away_from_zero).


Details
========

leaky_relu
--------------
- Replacement Sra to SraRound in stream (op method for streaming operator).
- Accordingly, fix verify/leaky_relu
    - Features which belong to negative will be calculated in "Decimal type". 

avg_pool
--------------
- Add substream div_const_flac as div operator corresponding to "rounding half away from zero".
- Replacement div_const of substream when to use denominator which isn't power of 2 number to div_const_frac.
- Also Replacement in  avg_pool_serial.
- Accordingly, fix verify/pool
    - All features will be calculated in "Decimal type". 

conv2d
---------------
- Add substream mul_rshfit_round_clip as operator correspoing  to "rounding half away from zero".
- Replacement substream mul_rshift_clip to mul_rshift_round_clip
- Accordingly, fix verify/conv2d
    - fix frac value to correspond to implementation of mul_rshift_round_clip


Note
==========
- This changes pass the test for basic operator, feature.
- But, some test which related to onnx is failing. 
