### PR TITLE
fix verify matmul

### DIFF
--- a/nngen/verify/matmul.py
+++ b/nngen/verify/matmul.py
@@ -28,12 +28,11 @@ def matmul(a, b,
     if transposed_a:
         a = a.transpose()
 
-    if not transposed_b:
-        b = b.transpose()
+    #if not transposed_b:
+    #    b = b.transpose()
 
     if a.shape[1] != b.shape[1]:
-        raise ValueError("shape mismatch: %s != %s" %
-                         str(a.shape), str(b.shape))
+        raise ValueError("shape mismatch: %s != %s" %(str(a.shape), str(b.shape)))
 
     c_shape = (a.shape[0], b.shape[0])
 

--- a/nngen/verify/matmul.py
+++ b/nngen/verify/matmul.py
@@ -28,12 +28,12 @@ def matmul(a, b,
     if transposed_a:
         a = a.transpose()
 
-    if not transposed_b:
-        b = b.transpose()
+    #if not transposed_b:
+    #    b = b.transpose()
 
     if a.shape[1] != b.shape[1]:
         raise ValueError("shape mismatch: %s != %s" %
-                         str(a.shape), str(b.shape))
+                         (str(a.shape), str(b.shape)))
 
     c_shape = (a.shape[0], b.shape[0])
 
@@ -118,6 +118,14 @@ def matmul(a, b,
                                          rshift_sum_pow),
                                 np.zeros_like(rshift_sum, dtype=np.int64))
 
+    rshift_out_pow = np.where(rshift_out > np.zeros_like(rshift_out, dtype=np.int64),
+                              rshift_out - 1,
+                              np.zeros_like(rshift_out))
+    rshift_out_round = np.where(rshift_out > np.zeros_like(rshift_out, dtype=np.int64),
+                                np.power(np.ones_like(rshift_out, dtype=np.int64) * 2,
+                                         rshift_out_pow),
+                                np.zeros_like(rshift_out, dtype=np.int64))
+
     a_point = 0 if a_dtype is None else a_dtype.point
     b_point = 0 if b_dtype is None else b_dtype.point
     bias_point = 0 if bias_dtype is None else bias_dtype.point
@@ -153,8 +161,8 @@ def matmul(a, b,
     def my_matmul_by_multiply(a, w):
         v = a.reshape([a.shape[0], 1, a.shape[1]])
         mul = np.multiply(v, w)
-        mul = np.right_shift(mul, mul_shift)
         mul = np.add(mul, rshift_mul_round.reshape([rshift_mul_round.shape[-1], 1]))
+        mul = np.right_shift(mul, mul_shift)
         mul = np.right_shift(mul, rshift_mul.reshape([rshift_mul.shape[-1], 1]))
         return np.add.reduce(mul, axis=2)
 
@@ -175,6 +183,9 @@ def matmul(a, b,
     sum = np.right_shift(sum, rshift_sum)
     sum = np.add(sum, shifted_bias)
     sum = np.multiply(sum, shifted_scale)
+    frac = np.where(rshift_out!=0, np.where(sum>=0, rshift_out_round, rshift_out_round - 1),
+            np.zeros_like(rshift_out, dtype=np.int64))
+    sum = np.add(sum,frac)
     sum = np.right_shift(sum, rshift_out)
     sum = np.where(sum > p_th, p_th, np.where(sum < n_th, n_th, sum))
 

--- a/tests/matrix_matmul/matrix_matmul.py
+++ b/tests/matrix_matmul/matrix_matmul.py
@@ -31,7 +31,9 @@ def run(a_shape=(15, 15), b_shape=(15, 15),
         bias_ram_size=None, scale_ram_size=None,
         out_ram_size=None,
         axi_datawidth=32, silent=False,
-        filename=None, simtype='iverilog', outputfile=None):
+        filename=None, simtype='iverilog', outputfile=None,
+        transposed_a = False, transposed_b = True
+        ):
 
     # create target hardware
     a = ng.placeholder(a_dtype, shape=a_shape, name='a')
@@ -47,8 +49,6 @@ def run(a_shape=(15, 15), b_shape=(15, 15),
     else:
         scale = None
 
-    transposed_a = False
-    transposed_b = True
 
     c = ng.matmul(a, b,
                   bias, scale,

--- a/tests/matrix_matmul/test_matrix_matmul_int16_non_transposed_b.py
+++ b/tests/matrix_matmul/test_matrix_matmul_int16_non_transposed_b.py
@@ -1,0 +1,90 @@
+from __future__ import absolute_import
+from __future__ import print_function
+
+import os
+import sys
+
+# the next line can be removed after installation
+sys.path.insert(0, os.path.dirname(os.path.dirname(
+    os.path.dirname(os.path.abspath(__file__)))))
+
+import nngen as ng
+import veriloggen
+
+import matrix_matmul
+
+
+a_shape = (11, 17)
+b_shape = (17, 13)
+bias_shape = None
+scale_shape = None
+a_dtype = ng.int16
+b_dtype = ng.int16
+bias_dtype = ng.int16
+scale_dtype = ng.int16
+c_dtype = ng.int16
+rshift_mul = None
+rshift_sum = None
+rshift_out = None
+act_func = None
+par_left_col = 2
+par_left_row = 1
+par_out_col = 2
+concur_out_col = None
+stationary = 'right'
+left_ram_size = None
+right_ram_size = None
+bias_ram_size = None
+scale_ram_size = None
+out_ram_size = None
+axi_datawidth = 32
+transposed_a = False
+transposed_b = False
+
+
+def test(request, silent=True):
+    veriloggen.reset()
+
+    simtype = request.config.getoption('--sim')
+
+    rslt = matrix_matmul.run(a_shape, b_shape,
+                             bias_shape, scale_shape,
+                             a_dtype, b_dtype,
+                             bias_dtype, scale_dtype,
+                             c_dtype,
+                             rshift_mul, rshift_sum, rshift_out,
+                             act_func,
+                             par_left_col, par_left_row, par_out_col,
+                             concur_out_col, stationary,
+                             left_ram_size, right_ram_size,
+                             bias_ram_size, scale_ram_size,
+                             out_ram_size,
+                             axi_datawidth, silent,
+                             filename=None, simtype=simtype,
+                             transposed_a = False,
+                             transposed_b = False,
+                             outputfile=os.path.splitext(os.path.basename(__file__))[0] + '.out')
+
+    verify_rslt = rslt.splitlines()[-1]
+    assert(verify_rslt == '# verify: PASSED')
+
+
+if __name__ == '__main__':
+    rslt = matrix_matmul.run(a_shape, b_shape,
+                             bias_shape, scale_shape,
+                             a_dtype, b_dtype,
+                             bias_dtype, scale_dtype,
+                             c_dtype,
+                             rshift_mul, rshift_sum, rshift_out,
+                             act_func,
+                             par_left_col, par_left_row, par_out_col,
+                             concur_out_col, stationary,
+                             left_ram_size, right_ram_size,
+                             bias_ram_size, scale_ram_size,
+                             out_ram_size,
+                             axi_datawidth, silent=False,
+                             filename='tmp.v',
+                             transposed_a = False,
+                             transposed_b = False,
+                             outputfile=os.path.splitext(os.path.basename(__file__))[0] + '.out')
+    print(rslt)


### PR DESCRIPTION
The eval mode is broken in the case of non transposing *B* in matmul *A@B* operation. 
Similarly, the case of transposing *A* (*A^T@B*) seems to be broken, but I haven't been able to track down the details of this case.
