### PR TITLE
Fix cparam literal format

### DIFF
--- a/nngen/basic_types.py
+++ b/nngen/basic_types.py
@@ -866,7 +866,7 @@ class _Operator(_Numeric):
         for name in self.collect_all_control_param_names():
             dst = getattr(self, name)
             if isinstance(dst, (tuple, list)):
-                for i, d in enumerate(dst):
+                for d in dst:
                     val_len = max(val_len, d.width)
             else:
                 val_len = max(val_len, dst.width)

--- a/nngen/basic_types.py
+++ b/nngen/basic_types.py
@@ -862,15 +862,23 @@ class _Operator(_Numeric):
         addrwidth = int(math.ceil(math.log(length, 2)))
         self.control_param_index_reg = self.m.Reg(self._name('control_param_index'),
                                                   addrwidth, initval=0)
+        val_len = 0
+        for name in self.collect_all_control_param_names():
+            dst = getattr(self, name)
+            if isinstance(dst, (tuple, list)):
+                for i, d in enumerate(dst):
+                    val_len = max(val_len, d.width)
+            else:
+                val_len = max(val_len, dst.width)
 
         pattern_dict = defaultdict(list)
         for i, values in enumerate(control_param_list):
             for name, value in values.items():
                 if isinstance(value, (tuple, list)):
-                    lst = [(self.control_param_index_reg == i, v) for v in value]
+                    lst = [(self.control_param_index_reg == i, vg.Int(v, width=val_len, base=16)) for v in value]
                     pattern_dict[name].append(lst)
                 else:
-                    pattern_dict[name].append((self.control_param_index_reg == i, value))
+                    pattern_dict[name].append((self.control_param_index_reg == i, vg.Int(value, width=val_len, base=16)))
 
         for name in self.collect_all_control_param_names():
             dst = getattr(self, name)


### PR DESCRIPTION
The immediate parameter as cparam in verilog file which is generated by NNgen, can keep large value over 32bit. 
Although, because of it isn't have bus width attribute, some simulator issue warning.
This PR make cparam to HEX format also keeping bus width attribute. 