### PR TITLE
Fix onnx/gemm.py to pass the tests/onnx_matrix_linear.

### DIFF
--- a/nngen/onnx/gemm.py
+++ b/nngen/onnx/gemm.py
@@ -22,21 +22,24 @@ def Gemm(visitor, node,
     for i, src in enumerate(node.input):
         src_node = util.search_node_from_model(visitor.model, src)
 
-        if (i == 0 and src_node.op_type == 'Flatten' and
-                len(visitor.consumers[src]) == 1):
+        if src_node is None:
+            pass
+        else:
+            if (i == 0 and src_node.op_type == 'Flatten' and
+                    len(visitor.consumers[src]) == 1):
 
-            src_obj = flatten.Flatten(visitor, src_node, no_transpose=True)
-            srcs.append(src_obj)
-            continue
-
-        if (i == 0 and src_node.op_type == 'Reshape' and
-                len(visitor.consumers[src]) == 1):
-
-            shape = visitor.visit(src_node.input[1])
-            if len(shape) == 2:
-                src_obj = reshape.Reshape(visitor, src_node, no_transpose=True)
+                src_obj = flatten.Flatten(visitor, src_node, no_transpose=True)
                 srcs.append(src_obj)
                 continue
+
+            if (i == 0 and src_node.op_type == 'Reshape' and
+                    len(visitor.consumers[src]) == 1):
+
+                shape = visitor.visit(src_node.input[1])
+                if len(shape) == 2:
+                    src_obj = reshape.Reshape(visitor, src_node, no_transpose=True)
+                    srcs.append(src_obj)
+                    continue
 
         src_obj = visitor.visit(src)
         srcs.append(src_obj)


### PR DESCRIPTION
I got the AttirbuteError in Gemm function when the src_node of gemm is a placeholder, such as inputs.
So I modified the gemm function to avoid this attribution error by skipping the 'op_type' reference to NoneType objects.